### PR TITLE
fixing a few more blockers and other low hanging fruits

### DIFF
--- a/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyDeployUI.cs
+++ b/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyDeployUI.cs
@@ -101,7 +101,8 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
         {
             int inputInt = base.InsertHorizLabeledConstrainedIntField(
                 _labelStr: "Rooms per process",
-                _tooltip: "For some lightweight servers, a single server instance (process) can handle multiple rooms/matches. If your server is built to support this, you can specify the number of rooms to fit on a process before spinning up a fresh instance.\n\n" +
+                _tooltip: "For most Unity multiplayer games, this should be left as 1\n\n" +
+                "For some lightweight servers, a single server instance (process) can handle multiple rooms/matches. If your server is built to support this, you can specify the number of rooms to fit on a process before spinning up a fresh instance.\n\n" +
                 "Default: 1",
                 _val: ServerConfig.HathoraDeployOpts.RoomsPerProcess,
                 _minVal: 1,

--- a/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyHeaderUI.cs
+++ b/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyHeaderUI.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hathora.Cloud.Sdk.Model;
@@ -297,11 +298,15 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
                 throw;
             }
               
-            // If selected app is -1 and apps count is > 0, select the first app
-            bool hasSelectedApp = ServerConfig.HathoraCoreOpts.ExistingAppsSelectedIndex != -1;
+            // If selected app is -1 or invalid and apps count is > 0, select the first app
+            bool hasSelectedApp = ServerConfig.HathoraCoreOpts.ExistingAppsSelectedIndex != -1 &&
+                ServerConfig.HathoraCoreOpts.ExistingAppsSelectedIndex < apps.Count;
+
             if (!hasSelectedApp && apps.Count > 0)
-                setSelectedApp(_newSelectedIndex: 0); 
-            
+            {
+                setSelectedApp(0);
+            }
+
             isRefreshingExistingApps = false;
         }
         

--- a/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyRoomUI.cs
+++ b/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyRoomUI.cs
@@ -226,7 +226,7 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
         private void insertCreateRoomLobbyCancelBtn(CancellationTokenSource _cancelTokenSrc)
         {
             string btnLabelStr = $"<color={HathoraEditorUtils.HATHORA_PINK_CANCEL_COLOR_HEX}>" +
-                "<b>Cancel</b> (Creating Room/Lobby...)</color>";
+                "<b>Cancel</b> (Creating Room...)</color>";
 
             // USER INPUT >>
             bool clickedCancelBtn = GUILayout.Button(btnLabelStr, GeneralButtonStyle);
@@ -293,7 +293,7 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
         {
             string btnLabelStr = isCreatingRoom 
                 ? "Creating Room..." 
-                : "Create Room/Lobby";
+                : "Create Room";
 
             EditorGUI.BeginDisabledGroup(disabled: !_enable);
             

--- a/src/Assets/Hathora/Core/Scripts/Runtime/Client/NetSession.cs
+++ b/src/Assets/Hathora/Core/Scripts/Runtime/Client/NetSession.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace Hathora.Core.Scripts.Runtime.Client
 {
     /// <summary>
-    /// Cached net session. Eg: Auth token, last room/lobby joined.
+    /// Cached net session. Eg: Auth token, last room joined.
     /// API wrappers will cache here on success.
     /// TODO: Move NetSession to Demo. This would require detaching cache saving from API wrappers.
     /// </summary>

--- a/src/Assets/Hathora/Core/Scripts/Runtime/Server/HathoraServerConfig.cs
+++ b/src/Assets/Hathora/Core/Scripts/Runtime/Server/HathoraServerConfig.cs
@@ -78,7 +78,7 @@ namespace Hathora.Core.Scripts.Runtime.Server
         /// <returns></returns>
         public bool MeetsCreateRoomBtnReqs() =>
             HathoraCoreOpts.HasAppId &&
-            HathoraLobbyRoomOpts.RegionSelectedIndex > 0 &&
+            HathoraLobbyRoomOpts.RegionSelectedIndex > -1 &&
             HathoraLobbyRoomOpts.HathoraRegion > 0;
 
         /// <summary>

--- a/src/Assets/Hathora/Core/Scripts/Runtime/Server/Models/HathoraCoreOpts.cs
+++ b/src/Assets/Hathora/Core/Scripts/Runtime/Server/Models/HathoraCoreOpts.cs
@@ -21,7 +21,7 @@ namespace Hathora.Core.Scripts.Runtime.Server.Models
         private int _existingAppsSelectedIndex = -1;
 
         /// <summary>Get from your Hathora dashboard</summary>
-        public string AppId => ExistingAppsWithDeployment != null && ExistingAppsWithDeployment.Count > 0 && _existingAppsSelectedIndex > 0
+        public string AppId => ExistingAppsWithDeployment != null && ExistingAppsWithDeployment.Count > 0 && _existingAppsSelectedIndex > -1 && _existingAppsSelectedIndex < ExistingAppsWithDeployment.Count
             ? ExistingAppsWithDeployment?[_existingAppsSelectedIndex]?.AppId
             : null;
         

--- a/src/Assets/Hathora/Core/Scripts/Runtime/Server/Models/HathoraLobbyRoomOpts.cs
+++ b/src/Assets/Hathora/Core/Scripts/Runtime/Server/Models/HathoraLobbyRoomOpts.cs
@@ -57,7 +57,7 @@ namespace Hathora.Core.Scripts.Runtime.Server.Models
         /// We check if there's a RoomId, and null checking leading up to it.
         /// </summary>
         public bool HasLastCreatedRoomConnection => 
-            !string.IsNullOrEmpty(_lastCreatedRoomConnection?.Room?.RoomId);
+            !string.IsNullOrEmpty(_lastCreatedRoomConnection?.Room?.RoomId) && _lastCreatedRoomConnection?.ConnectionInfoV2?.ExposedPort != null;
         #endregion // Hathora Region
     }
 }


### PR DESCRIPTION
Fixes:
- Fixed bug where selected app index could be cached that was no longer valid (user switches to account with less apps)
- Remove mention of `Lobby` in labels and buttons
- Fixed additional spot where Seattle Region (index 0) was invalid
- Fix/added null checks for `ConnectionInfoV2.ExposedPorts` and `AppId`
- Improve roomsPerProcess tooltip to make it clear it should rarely be changed from 1