### PR TITLE
Refactor/rm on start awake

### DIFF
--- a/src/Assets/Hathora/Core/Scripts/Runtime/Client/ApiWrapper/HathoraClientLobbyApi.cs
+++ b/src/Assets/Hathora/Core/Scripts/Runtime/Client/ApiWrapper/HathoraClientLobbyApi.cs
@@ -138,6 +138,7 @@ namespace Hathora.Core.Scripts.Runtime.Client.ApiWrapper
         }
 
         /// <summary>
+        /// Gets a list of active+public lobbies.
         /// </summary>
         /// <param name="_region">Leave null to return ALL Regions</param>
         /// <param name="_cancelToken"></param>
@@ -146,9 +147,10 @@ namespace Hathora.Core.Scripts.Runtime.Client.ApiWrapper
             Region? _region = null, // null == ALL regions
             CancellationToken _cancelToken = default)
         {
-            Debug.Log("[NetHathoraClientLobbyApi.ClientCreateLobbyAsync] " +
-                $"<color=yellow>region: {_region}</color> (This will exclude " +
-                $"private lobbies and server Rooms created without a lobby)");
+            string logsPrefix = $"[HathoraClientLobbyApi.{nameof(ClientListPublicLobbiesAsync)}]";
+            string regionStr = _region == null ? "any" : _region.ToString();
+            
+            Debug.Log($"{logsPrefix} <color=yellow>Getting public+active lobbies for '{regionStr}' region</color>");
             
             List<Lobby> lobbies;
             try
@@ -166,15 +168,13 @@ namespace Hathora.Core.Scripts.Runtime.Client.ApiWrapper
                     apiException);
                 
                 if (apiException.ErrorCode == 404)
-                    Debug.LogError("[404] Tip: If a server made a Room without a lobby, " +
+                    Debug.LogError($"{logsPrefix} 404: If a server made a Room without a lobby, " +
                         "instead use the Room api (rather than Lobby api)");
                 
                 return null; // fail
             }
 
-            Debug.Log($"[NetHathoraClientLobbyApi] ClientListPublicLobbiesAsync => " +
-                $"numLobbiesFound: {lobbies?.Count ?? 0}");
-            
+            Debug.Log($"{logsPrefix} => numLobbiesFound: {lobbies?.Count ?? 0}");
             return lobbies;
         }
         #endregion // Client Lobby Async Hathora SDK Calls

--- a/src/Assets/Hathora/Core/Scripts/Runtime/Server/HathoraServerMgrBase.cs
+++ b/src/Assets/Hathora/Core/Scripts/Runtime/Server/HathoraServerMgrBase.cs
@@ -89,8 +89,7 @@ namespace Hathora.Core.Scripts.Runtime.Server
 
         
         #region Init
-        private void Awake() => OnAwake();
-        protected virtual void OnAwake()
+        protected virtual void Awake()
         {
 #if !UNITY_SERVER && !UNITY_EDITOR
             Debug.Log("(!) [HathoraServerMgrBase.Awake] Destroying - not a server");
@@ -118,14 +117,6 @@ namespace Hathora.Core.Scripts.Runtime.Server
             _ = GetHathoraProcessFromEnvVarAsync(); // !await
         }
 
-        /// <summary>If we were not server || editor, we'd already be destroyed @ Awake</summary>
-        private void Start() => OnStart();
-
-        /// <summary>If we were not server || editor, we'd already be destroyed @ Awake</summary>
-        protected virtual void OnStart()
-        {
-        }
-
         /// <param name="_overrideProcIdVal">Mock a val for testing within the Editor</param>
         protected virtual string getServerDeployedProcessId(string _overrideProcIdVal = null)
         {
@@ -139,7 +130,7 @@ namespace Hathora.Core.Scripts.Runtime.Server
             return Environment.GetEnvironmentVariable("HATHORA_PROCESS_ID");
         }
 
-        // /// <summary>TODO: Mv to child</summary>
+        ///// <summary>You probably want to set this on child @ awake</summary>
         // private void setSingleton() { }
         // {
         //     if (Singleton != null)
@@ -184,7 +175,7 @@ namespace Hathora.Core.Scripts.Runtime.Server
         /// Gets the Server process info by a special env var that's
         /// *always* included (automatically) in Hathora deployments.
         ///
-        /// You probably want to call this @ OnAwake, then get cached ver later @ GetCachedHathoraProcessAsync()
+        /// You probably want to call this @ Awake, then get cached ver later @ GetCachedHathoraProcessAsync()
         /// </summary>
         protected virtual async Task GetHathoraProcessFromEnvVarAsync()
         {
@@ -203,7 +194,7 @@ namespace Hathora.Core.Scripts.Runtime.Server
         /// <summary>
         /// systemHathoraProcess tries to set async @ Awake, but it could still take some time.
         /// We'll await until != null for 5s before timing out.
-        /// We initially set this @ OnAwake via getHathoraProcessFromEnvVarAsync.
+        /// We initially set this @ Awake via getHathoraProcessFromEnvVarAsync.
         /// TODO: Accept custom cancelToken
         /// </summary>
         /// <returns></returns>
@@ -253,7 +244,7 @@ namespace Hathora.Core.Scripts.Runtime.Server
             HathoraGetDeployInfoResult getDeployInfoResult = new(serverDeployedProcessId);
             
             // ----------------
-            // Get Process from env var "HATHORA_PROCESS_ID" => We probably cached this, already, @ OnAwake()
+            // Get Process from env var "HATHORA_PROCESS_ID" => We probably cached this, already, @ Awake()
             // We await => just in case we called this early, to prevent race conditions
             Process processInfo = await GetCachedHathoraProcessAsync();
             string procId = processInfo.ProcessId;

--- a/src/Assets/Hathora/Demos/1-FishNetDemo/HathoraScripts/Client/ClientMgr/HathoraFishnetClientMgr.cs
+++ b/src/Assets/Hathora/Demos/1-FishNetDemo/HathoraScripts/Client/ClientMgr/HathoraFishnetClientMgr.cs
@@ -29,9 +29,18 @@ namespace Hathora.Demos._1_FishNetDemo.HathoraScripts.Client.ClientMgr
 
         
         #region Init
-        /// <summary>SetSingleton(), SetTransport()</summary>
-        protected override void OnAwake() =>
-            base.OnAwake();
+        /// <summary>Be sure to override when using Start() + Awake()</summary>
+        protected override void Awake() =>
+            base.Awake();
+        
+        protected override void Start()
+        {
+            base.Start();
+            base.InitOnStart(HathoraFishnetClientMgrDemoUi.Singleton); // Allows UI calls on logic callbacks
+            
+            // This is a Client manager script; listen for relative events
+            InstanceFinder.ClientManager.OnClientConnectionState += OnClientConnectionState;
+        }
 
         protected override void SetSingleton()
         {
@@ -43,15 +52,6 @@ namespace Hathora.Demos._1_FishNetDemo.HathoraScripts.Client.ClientMgr
             }
 
             Singleton = this;
-        }
-
-        protected override void OnStart()
-        {
-            base.InitOnStart(HathoraFishnetClientMgrDemoUi.Singleton);
-            base.OnStart();
-            
-            // This is a Client manager script; listen for relative events
-            InstanceFinder.ClientManager.OnClientConnectionState += OnClientConnectionState;
         }
         #endregion // Init
         

--- a/src/Assets/Hathora/Demos/1-FishNetDemo/HathoraScripts/Client/ClientMgr/HathoraFishnetClientMgrDemoUi.cs
+++ b/src/Assets/Hathora/Demos/1-FishNetDemo/HathoraScripts/Client/ClientMgr/HathoraFishnetClientMgrDemoUi.cs
@@ -22,10 +22,10 @@ namespace Hathora.Demos._1_FishNetDemo.HathoraScripts.Client.ClientMgr
         
 
         #region Init
-        protected override void OnStart()
+        protected override void Start()
         {
-            base.OnStart();
-            InitOnStart(HathoraClientMgr);
+            base.Start();
+            InitOnStart(HathoraClientMgr); // Allows logic calls on UI interactions
         }
         
         protected override void SetSingleton()
@@ -51,6 +51,7 @@ namespace Hathora.Demos._1_FishNetDemo.HathoraScripts.Client.ClientMgr
             HathoraClientMgr.StartServer();
         }
 
+        /// <summary></summary>
         /// <param name="_hostPortOverride">
         /// Normally passes the host:port provided by Hathora, but FishNet
         /// specifically gets it from the Ui.clientConnectInputField
@@ -73,6 +74,7 @@ namespace Hathora.Demos._1_FishNetDemo.HathoraScripts.Client.ClientMgr
             HathoraClientMgr.StartClient(_hostPortOverride);
         }
 
+        
         public override void OnStartHostBtnClick()
         {
             base.OnStartHostBtnClick();

--- a/src/Assets/Hathora/Demos/1-FishNetDemo/HathoraScripts/Server/HathoraFishnetServerMgr.cs
+++ b/src/Assets/Hathora/Demos/1-FishNetDemo/HathoraScripts/Server/HathoraFishnetServerMgr.cs
@@ -22,10 +22,10 @@ namespace Hathora.Demos._1_FishNetDemo.HathoraScripts.Server
         }
 
         #region Init
-        protected override void OnAwake()
+        protected override void Awake()
         {
-            Debug.Log("[HathoraFishnetServerMgr] OnAwake");
-            base.OnAwake();
+            Debug.Log("[HathoraFishnetServerMgr] Awake");
+            base.Awake();
             setSingleton();
         }
     

--- a/src/Assets/Hathora/Demos/2-MirrorDemo/HathoraScripts/Client/ClientMgr/HathoraMirrorClientMgr.cs
+++ b/src/Assets/Hathora/Demos/2-MirrorDemo/HathoraScripts/Client/ClientMgr/HathoraMirrorClientMgr.cs
@@ -41,10 +41,22 @@ namespace Hathora.Demos._2_MirrorDemo.HathoraScripts.Client.ClientMgr
         
 
         #region Init
-        /// <summary>SetSingleton(), SetTransport()</summary>
-        protected override void OnAwake() =>
-            base.OnAwake();
+        /// <summary>Be sure to override when using Start() + Awake()</summary>
+        protected override void Awake() =>
+            base.Awake();
 
+        protected override void Start()
+        {
+            base.Start();
+            base.InitOnStart(HathoraMirrorClientMgrDemoUi.Singleton); // Allows logic callbacks to trigger UI events
+
+            // This is a Client manager script; listen for relative events
+            transport.OnClientConnected += base.OnConnectSuccess;
+            transport.OnClientError += onMirrorClientError;
+            transport.OnClientDisconnected += () => 
+                base.OnConnectFailed("Disconnected");;
+        }
+        
         protected override void SetSingleton()
         {
             if (Singleton != null)
@@ -55,18 +67,6 @@ namespace Hathora.Demos._2_MirrorDemo.HathoraScripts.Client.ClientMgr
             }
 
             Singleton = this;
-        }
-
-        protected override void OnStart()
-        {
-            base.InitOnStart(HathoraMirrorClientMgrDemoUi.Singleton);
-            base.OnStart();
-
-            // This is a Client manager script; listen for relative events
-            transport.OnClientConnected += base.OnConnectSuccess;
-            transport.OnClientError += onMirrorClientError;
-            transport.OnClientDisconnected += () => 
-                base.OnConnectFailed("Disconnected");;
         }
         #endregion // Init
         

--- a/src/Assets/Hathora/Demos/2-MirrorDemo/HathoraScripts/Client/ClientMgr/HathoraMirrorClientMgrDemoUi.cs
+++ b/src/Assets/Hathora/Demos/2-MirrorDemo/HathoraScripts/Client/ClientMgr/HathoraMirrorClientMgrDemoUi.cs
@@ -24,10 +24,10 @@ namespace Hathora.Demos._2_MirrorDemo.HathoraScripts.Client.ClientMgr
         
 
         #region Init
-        protected override void OnStart()
+        protected override void Start()
         {
-            base.OnStart();
-            InitOnStart(HathoraClientMgr);
+            base.Start();
+            InitOnStart(HathoraClientMgr); // Allows logic alls on UI interactions
         }
 
         protected override void SetSingleton()

--- a/src/Assets/Hathora/Demos/Shared/Scripts/Client/ClientMgr/HathoraClientMgrBase.cs
+++ b/src/Assets/Hathora/Demos/Shared/Scripts/Client/ClientMgr/HathoraClientMgrBase.cs
@@ -55,12 +55,15 @@ namespace Hathora.Demos.Shared.Scripts.Client.ClientMgr
 
         
         #region Init
-        private void Awake() => OnAwake();
-        private void Start() => OnStart();
-        
-        protected virtual void OnAwake()
+        protected virtual void Awake()
         {
             SetSingleton();
+        }
+        
+        protected virtual void Start()
+        {
+            validateReqs();
+            initApis(_hathoraSdkConfig: null); // Base will create this
         }
 
         /// <summary>
@@ -68,19 +71,16 @@ namespace Hathora.Demos.Shared.Scripts.Client.ClientMgr
         /// </summary>
         protected abstract void SetSingleton();
 
-        /// <summary>Override OnStart and call this before anything.</summary>
+        /// <summary>
+        /// If you want to trigger UI from Mgr callbacks:
+        /// Override OnStart and call this before anything.
+        /// </summary>
         /// <param name="_clientMgrDemoUi"></param>
         protected virtual void InitOnStart(HathoraClientMgrDemoUi _clientMgrDemoUi)
         {
             ClientMgrDemoUi = _clientMgrDemoUi;
         }
 
-        protected virtual void OnStart()
-        {
-            validateReqs();
-            initApis(_hathoraSdkConfig: null); // Base will create this
-        }
-        
         /// <summary>
         /// Init all Client API wrappers. Uses serialized HathoraClientConfig
         /// </summary>

--- a/src/Assets/Hathora/Demos/Shared/Scripts/Client/ClientMgr/HathoraClientMgrDemoUi.cs
+++ b/src/Assets/Hathora/Demos/Shared/Scripts/Client/ClientMgr/HathoraClientMgrDemoUi.cs
@@ -47,22 +47,19 @@ namespace Hathora.Demos.Shared.Scripts.Client.ClientMgr
 
 
         #region Init
-        private void Awake() => 
-            OnAwake();
-        
-        private void Start() => 
-            OnStart();
-
-        protected virtual void OnAwake() =>
+        protected virtual void Awake() =>
             SetSingleton();
 
         /// <summary>Override + Call InitOnStart</summary>
-        protected virtual void OnStart()
+        protected virtual void Start()
         {
+            //// Call from child so UI interactions can call logic
             // InitOnStart(hathoraClientBase);
         }
 
-        /// <summary>Call me @ OnStart</summary>
+        /// <summary>
+        /// Call me @ child Start so we can call logic events on UI inputs (btn clicks, etc).
+        /// </summary>
         protected void InitOnStart(HathoraClientMgrBase _hathoraClientMgrBase)
         {
             if (_hathoraClientMgrBase == null)


### PR DESCRIPTION
OnAwake/OnStart were legacy workarounds for a Unity 5.x bug (or lacking feature) that seems to be working fine now in modern Unity LTS': Swapped out for a normal [protected virtual] Start/Awake.