### PR TITLE
fix!: Consider stopped Hathora Process

### DIFF
--- a/src/Assets/Hathora/Core/Scripts/Runtime/Server/ApiWrapper/HathoraServerProcessApi.cs
+++ b/src/Assets/Hathora/Core/Scripts/Runtime/Server/ApiWrapper/HathoraServerProcessApi.cs
@@ -41,10 +41,12 @@ namespace Hathora.Core.Scripts.Runtime.Server.ApiWrapper
         /// <param name="_processId">
         /// The process running the Room; find it in web console or GetRunningProcesses().
         /// </param>
+        /// <param name="_returnNullOnStoppedProcess">If the Process stopped (no Rooms inside), just return null</param>
         /// <param name="_cancelToken"></param>
         /// <returns>Returns Process on success</returns>
         public async Task<Process> GetProcessInfoAsync(
             string _processId,
+            bool _returnNullOnStoppedProcess = true,
             CancellationToken _cancelToken = default)
         {
             const string logPrefix = "[HathoraServerProcessApi.GetProcessInfoAsync]";
@@ -69,6 +71,14 @@ namespace Hathora.Core.Scripts.Runtime.Server.ApiWrapper
 
             Debug.Log($"{logPrefix} Success: <color=yellow>" +
                 $"getProcessInfoResult: {getProcessInfoResult.ToJson()}</color>");
+            
+            
+            if (getProcessInfoResult.StoppingAt != null)
+            {
+                Debug.LogError($"{logPrefix} Got Process info, but reported <color=orange>Stopped</color> " +
+                    $"(returnNullOnStoppedProcess=={_returnNullOnStoppedProcess})");
+                return null;
+            }
 
             return getProcessInfoResult;
         }


### PR DESCRIPTION
## About

* This is essentially a hotfix extension of https://github.com/hathora/hathora-unity/pull/14
* Getting the Hathora Process was considered a success if != null, but we should have additionally been checking if there's an end DateTime (the Process idled out or otherwise closed).

## Changes

* (!) This adds a new optional arg to `GetProcessInfoAsync` for returnNullOnStoppedProcess
* Adds additional logs
* For HathoraServerMgr.GetServerContextAsync, null checks and defaults `true` for returnNullOnStoppedProcess.
* Moved extended err logs from !Room to !Process