### PR TITLE
Feat/server config dropdown state cache

### DIFF
--- a/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyBuildUI.cs
+++ b/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyBuildUI.cs
@@ -17,8 +17,11 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
     {
         #region Vars
         // Foldouts
-        private bool isServerBuildFoldout;
+        private bool isBuildFoldout;
         private CancellationTokenSource cancelBuildTokenSrc;
+        
+        /// <summary>For state persistence on which dropdown group was last clicked</summary>
+        protected const string SERVER_BUILD_SETTINGS_FOLDOUT_STATE_KEY = "ServerBuildSettingsFoldoutState";
         #endregion // Vars
 
 
@@ -45,11 +48,22 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
 
         private void insertServerBuildSettingsFoldout()
         {
-            isServerBuildFoldout = EditorGUILayout.BeginFoldoutHeaderGroup(
-                isServerBuildFoldout,
+            // Retrieve the saved foldout state from EditorPrefs
+            isBuildFoldout = EditorPrefs.GetBool(
+                SERVER_BUILD_SETTINGS_FOLDOUT_STATE_KEY, 
+                defaultValue: false);
+            
+            // Create the foldout
+            isBuildFoldout = EditorGUILayout.BeginFoldoutHeaderGroup(
+                isBuildFoldout,
                 "Server Build Settings");
+            
+            // Save the new foldout state to EditorPrefs
+            EditorPrefs.SetBool(
+                SERVER_BUILD_SETTINGS_FOLDOUT_STATE_KEY, 
+                isBuildFoldout);
 
-            if (!isServerBuildFoldout)
+            if (!isBuildFoldout)
             {
                 EditorGUILayout.EndFoldoutHeaderGroup();
                 return;

--- a/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyDeployUI.cs
+++ b/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyDeployUI.cs
@@ -23,6 +23,9 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
         
         // Foldouts
         private bool isDeploymentFoldout;
+        
+        /// <summary>For state persistence on which dropdown group was last clicked</summary>
+        protected const string SERVER_DEPLOY_SETTINGS_FOLDOUT_STATE_KEY = "ServerDeploySettingsFoldoutState";
         #endregion // Vars
 
 
@@ -62,9 +65,20 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
 
         private void insertDeploymentSettingsFoldout()
         {
+            // Retrieve the saved foldout state from EditorPrefs
+            isDeploymentFoldout = EditorPrefs.GetBool(
+                SERVER_DEPLOY_SETTINGS_FOLDOUT_STATE_KEY, 
+                defaultValue: false);
+            
+            // Create the foldout
             isDeploymentFoldout = EditorGUILayout.BeginFoldoutHeaderGroup(
                 isDeploymentFoldout, 
                 "Hathora Deployment Configuration");
+            
+            // Save the new foldout state to EditorPrefs
+            EditorPrefs.SetBool(
+                SERVER_DEPLOY_SETTINGS_FOLDOUT_STATE_KEY, 
+                isDeploymentFoldout);
             
             if (!isDeploymentFoldout)
             {

--- a/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyRoomUI.cs
+++ b/src/Assets/Hathora/Core/Scripts/Editor/Server/ConfigStyle/PostAuth/HathoraConfigPostAuthBodyRoomUI.cs
@@ -35,7 +35,10 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
         private readonly List<int> originalIndices;
         
         // Foldouts
-        private bool isCreateRoomLobbyFoldout;
+        private bool isRoomFoldout;
+        
+        /// <summary>For state persistence on which dropdown group was last clicked</summary>
+        protected const string SERVER_ROOM_SETTINGS_FOLDOUT_STATE_KEY = "ServerRoomSettingsFoldoutState";
         #endregion // Vars
 
 
@@ -98,11 +101,22 @@ namespace Hathora.Core.Scripts.Editor.Server.ConfigStyle.PostAuth
 
         private void insertCreateRoomFoldout()
         {
-            isCreateRoomLobbyFoldout = EditorGUILayout.BeginFoldoutHeaderGroup(
-                isCreateRoomLobbyFoldout, 
+            // Retrieve the saved foldout state from EditorPrefs
+            isRoomFoldout = EditorPrefs.GetBool(
+                SERVER_ROOM_SETTINGS_FOLDOUT_STATE_KEY, 
+                defaultValue: false);
+            
+            // Create the foldout
+            isRoomFoldout = EditorGUILayout.BeginFoldoutHeaderGroup(
+                isRoomFoldout, 
                 "Create Room");
             
-            if (!isCreateRoomLobbyFoldout)
+            // Save the new foldout state to EditorPrefs
+            EditorPrefs.SetBool(
+                SERVER_ROOM_SETTINGS_FOLDOUT_STATE_KEY, 
+                isRoomFoldout);
+            
+            if (!isRoomFoldout)
             {
                 EditorGUILayout.EndFoldoutHeaderGroup();
                 return;


### PR DESCRIPTION
## Prereqs

None

## About

`HathoraServerConfig` now remembers your collapsed/expanded dropdown group state as you leave the inspector<>return:

 (GIF)
![Unity_NRJTFa95pU](https://github.com/hathora/hathora-unity/assets/8840024/e9c007c7-4691-4159-b5d1-6cca38f0da7f)