### PR TITLE
Fix script compilation issues for Unity 6

### DIFF
--- a/src/Assets/Hathora/Hathora.Cloud.Sdk/HathoraCloud/Utils/SpeakeasyHttpClient.cs
+++ b/src/Assets/Hathora/Hathora.Cloud.Sdk/HathoraCloud/Utils/SpeakeasyHttpClient.cs
@@ -11,6 +11,7 @@
 namespace HathoraCloud.Utils
 {
     using System.Collections.Generic;
+    using UnityEngine;
     using UnityEngine.Networking;
     using System.Threading.Tasks;
 

--- a/src/Assets/Hathora/Hathora.Cloud.Sdk/HathoraCloud/Utils/Utilities.cs
+++ b/src/Assets/Hathora/Hathora.Cloud.Sdk/HathoraCloud/Utils/Utilities.cs
@@ -312,6 +312,7 @@ namespace HathoraCloud.Utils
         }
     }
 
+#if !UNITY_6000_0_OR_NEWER
     public static class ExtensionMethods
     {
         ///<summmary>
@@ -327,4 +328,5 @@ namespace HathoraCloud.Utils
             return ((Task)tcs.Task).GetAwaiter();
         }
     }
+#endif
 }


### PR DESCRIPTION
This PR fixes 2 compilation issues with the Hathora plugin for Unity versions 6000+:

- The `SpeakeasyHttpClient.cs` needed an explicit `using UnrealEngine;`
- Unity 6 includes support for `await`, so I added a flag to only include the `GetAwaiter` for versions older than 6000

This was tested on Unity 2022 LTS, but had some issues testing on Unity 6000 due to unrelated TextMeshPro issues with the demo.